### PR TITLE
SCRUM-149-BUG-invalid-link-check-in-exercise-popup-fixed

### DIFF
--- a/api/src/main/java/ee/tlu/evkk/api/controller/ExerciseController.java
+++ b/api/src/main/java/ee/tlu/evkk/api/controller/ExerciseController.java
@@ -184,7 +184,7 @@ public class ExerciseController {
       String[] parts = parsedUrl.getPath().split("/");
 
       if (parts.length < 3 || !parts[1].equals("node")) {
-        return ResponseEntity.badRequest().body(Map.of("status", "error", "message", "INVALID_PATH_FORMAT"));
+        return ResponseEntity.badRequest().body(Map.of("status", "error", "message", "ERROR_INVALID_PATH_FORMAT"));
       }
 
       String externalId = parts[2];

--- a/ui/src/elle/components/snackbar/ErrorSnackbar.js
+++ b/ui/src/elle/components/snackbar/ErrorSnackbar.js
@@ -57,5 +57,5 @@ export const ErrorSnackbarEventType = {
   UNAUTHORIZED: 'error_unauthorized',
   UNSUPPORTED_MIMETYPE: 'error_unsupported_mimetype',
   INVALID_LINK: 'error_invalid_link',
-//  FAILED_TO_SAVE_FILE: 'error_failed_to_save_file'
+  ALREADY_EXISTS_LINK: 'error_link_already_exists'
 };

--- a/ui/src/elle/pages/Exercises.js
+++ b/ui/src/elle/pages/Exercises.js
@@ -76,7 +76,7 @@ export default function Exercise() {
               </div>
 
               <div className="library-results-count">
-                <Box>{t('query_found')}: {currentExercises.length}</Box>
+                <Box>{t('query_found')}: {exercises.length}</Box>
               </div>
 
               <div className="library-results">

--- a/ui/src/elle/translations/en/translations.js
+++ b/ui/src/elle/translations/en/translations.js
@@ -721,5 +721,5 @@ export const TRANSLATIONS_EN = {
   wordlist_wordcloud_filename: 'wordcloud',
   wordlist_wordcloud_loading: 'Loading word cloud...',
   error_invalid_link: 'Please check the link before continuing.',
-//  error_failed_to_save_file: 'Failed to save the file. Please try again later.'
+  error_link_already_exists: 'An exercise with this link has already been saved'
 };

--- a/ui/src/elle/translations/et/translations.js
+++ b/ui/src/elle/translations/et/translations.js
@@ -723,5 +723,5 @@ export const TRANSLATIONS_ET = {
   wordlist_wordcloud_filename: 'sonapilv',
   wordlist_wordcloud_loading: 'Laadin sõnapilve...',
   error_invalid_link: 'Link on vigane. Palun kontrolli linki enne jätkamist.',
-  error_link_already_exists: 'Selle lingiga seotud harjutus on juba salvestatud'
+  error_link_already_exists: 'See harjutus on juba süsteemi sisestatud.'
 };

--- a/ui/src/elle/translations/et/translations.js
+++ b/ui/src/elle/translations/et/translations.js
@@ -723,5 +723,5 @@ export const TRANSLATIONS_ET = {
   wordlist_wordcloud_filename: 'sonapilv',
   wordlist_wordcloud_loading: 'Laadin sõnapilve...',
   error_invalid_link: 'Link on vigane. Palun kontrolli linki enne jätkamist.',
-//  error_failed_to_save_file: 'Faili salvestamine ebaõnnestus. Palun proovige veel kord mõne aja pärast.'
+  error_link_already_exists: 'Selle lingiga seotud harjutus on juba salvestatud'
 };

--- a/ui/src/elle/util/ExerciseUtils.js
+++ b/ui/src/elle/util/ExerciseUtils.js
@@ -24,7 +24,7 @@ export const validateLink = async (link, fetchData) => {
     });
 
     return {
-      status: response.status === 'ok' || response.status === 'already_exists' ? 'success' : 'error',
+      status: response.status,
       externalId: response.external_id || null,
     };
   } catch {


### PR DESCRIPTION
* Fixed length of exercises
* Added validation for invalid or duplicate links in the exercise creation popup.
* Fixed bug form data after closing the exercise creation modal to prevent old input from reappearing
![image](https://github.com/user-attachments/assets/8a758673-1853-48cc-88bc-9d8a70d26e2a)![image](https://github.com/user-attachments/assets/a5a2b496-6cda-4c25-a790-d1bb98dd4d42)



